### PR TITLE
Update gauge fixing to work with symmetries

### DIFF
--- a/examples/heisenberg.jl
+++ b/examples/heisenberg.jl
@@ -27,8 +27,7 @@ ctmalg = CTMRG(; trscheme=truncdim(χenv), tol=1e-10, miniter=4, maxiter=100, ve
 alg = PEPSOptimize(;
     boundary_alg=ctmalg,
     optimizer=LBFGS(4; maxiter=100, gradtol=1e-4, verbosity=2),
-    # gradient_alg=GMRES(; tol=1e-6, maxiter=100),
-    gradient_alg=ManualIter(; tol=1e-6, maxiter=100),
+    gradient_alg=GMRES(; tol=1e-6, maxiter=100),
     reuse_env=true,
     verbosity=2,
 )

--- a/examples/heisenberg.jl
+++ b/examples/heisenberg.jl
@@ -27,7 +27,8 @@ ctmalg = CTMRG(; trscheme=truncdim(χenv), tol=1e-10, miniter=4, maxiter=100, ve
 alg = PEPSOptimize(;
     boundary_alg=ctmalg,
     optimizer=LBFGS(4; maxiter=100, gradtol=1e-4, verbosity=2),
-    gradient_alg=GMRES(; tol=1e-6, maxiter=100),
+    # gradient_alg=GMRES(; tol=1e-6, maxiter=100),
+    gradient_alg=ManualIter(; tol=1e-6, maxiter=100),
     reuse_env=true,
     verbosity=2,
 )

--- a/examples/test_gauge_fixing.jl
+++ b/examples/test_gauge_fixing.jl
@@ -11,12 +11,21 @@ function test_gauge_fixing(
     ctmalg = CTMRG(;
         trscheme=truncdim(χenv), tol=1e-10, miniter=4, maxiter=100, verbosity=2
     )
+    ctmalg_fixed = CTMRG(;
+        trscheme=truncdim(χenv),
+        tol=1e-10,
+        miniter=4,
+        maxiter=100,
+        verbosity=2,
+        fixedspace=true,
+    )
+
     env = leading_boundary(ψ, ctmalg, env)
 
     println("Testing gauge fixing for $(sectortype(P)) symmetry and $unitcell unit cell.")
 
     println("\nBefore gauge-fixing:")
-    env′, = PEPSKit.ctmrg_iter(ψ, env, ctmalg)
+    env′, = PEPSKit.ctmrg_iter(ψ, env, ctmalg_fixed)
     @show PEPSKit.check_elementwise_convergence(env, env′)
 
     println("\nAfter gauge-fixing:")

--- a/examples/test_gauge_fixing.jl
+++ b/examples/test_gauge_fixing.jl
@@ -36,7 +36,7 @@ test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(1, 1))
 test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(2, 2))
 test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(3, 4)) # check gauge-fixing for unit cells > (2, 2)
 
-# Convergence of real CTMRG seems to be more sensitive to initial guesse
+# Convergence of real CTMRG seems to be more sensitive to initial guess
 test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(1, 1))
 test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(2, 2))
 test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(3, 4))

--- a/examples/test_gauge_fixing.jl
+++ b/examples/test_gauge_fixing.jl
@@ -34,6 +34,7 @@ E = ℂ^χenv # environment virtual space
 
 test_gauge_fixing(P, V, E; χenv, unitcell=(1, 1))
 test_gauge_fixing(P, V, E; χenv, unitcell=(2, 2))
+test_gauge_fixing(P, V, E; χenv, unitcell=(3, 4)) # check gauge-fixing for unit cells > (2, 2)
 
 # Z2
 

--- a/examples/test_gauge_fixing.jl
+++ b/examples/test_gauge_fixing.jl
@@ -3,9 +3,9 @@ using TensorKit, MPSKitModels, OptimKit
 using PEPSKit
 
 function test_gauge_fixing(
-    P::S, V::S, E::S; χenv::Int=20, unitcell::NTuple{2,Int}=(1, 1)
+    f, T, P::S, V::S, E::S; χenv::Int=20, unitcell::NTuple{2,Int}=(1, 1)
 ) where {S<:ElementarySpace}
-    ψ = InfinitePEPS(P, V; unitcell)
+    ψ = InfinitePEPS(f, T, P, V; unitcell)
     env = CTMRGEnv(ψ; Venv=E)
 
     ctmalg = CTMRG(;
@@ -32,9 +32,14 @@ V = ℂ^2 # PEPS virtual space
 χenv = 20 # environment truncation dimension
 E = ℂ^χenv # environment virtual space
 
-test_gauge_fixing(P, V, E; χenv, unitcell=(1, 1))
-test_gauge_fixing(P, V, E; χenv, unitcell=(2, 2))
-test_gauge_fixing(P, V, E; χenv, unitcell=(3, 4)) # check gauge-fixing for unit cells > (2, 2)
+test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(1, 1))
+test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(2, 2))
+test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(3, 4)) # check gauge-fixing for unit cells > (2, 2)
+
+# Convergence of real CTMRG seems to be more sensitive to initial guesse
+test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(1, 1))
+test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(2, 2))
+test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(3, 4))
 
 # Z2
 
@@ -43,5 +48,8 @@ V = Z2Space(0 => 2, 1 => 2) # PEPS virtual space
 χenv = 20 # environment truncation dimension
 E = Z2Space(0 => χenv / 2, 1 => χenv / 2) # environment virtual space
 
-test_gauge_fixing(P, V, E; χenv, unitcell=(1, 1))
-test_gauge_fixing(P, V, E; χenv, unitcell=(2, 2))
+test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(1, 1))
+test_gauge_fixing(randn, ComplexF64, P, V, E; χenv, unitcell=(2, 2))
+
+test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(1, 1))
+test_gauge_fixing(randn, Float64, P, V, E; χenv, unitcell=(2, 2))

--- a/examples/test_gradients.jl
+++ b/examples/test_gradients.jl
@@ -2,6 +2,12 @@ using LinearAlgebra
 using TensorKit, MPSKitModels, OptimKit
 using PEPSKit, KrylovKit
 
+
+using Zygote
+
+
+    
+
 # Square lattice Heisenberg Hamiltonian
 function square_lattice_heisenberg(; Jx=-1.0, Jy=1.0, Jz=-1.0)
     Sx, Sy, Sz, _ = spinmatrices(1//2)
@@ -36,11 +42,11 @@ function compute_grad(gradient_alg)
     return g
 end
 
-g_naive = compute_grad(NaiveAD())
-g_geomsum = compute_grad(GeomSum())
-g_maniter = compute_grad(ManualIter())
-g_linsolve = compute_grad(KrylovKit.GMRES(; tol=1e-6))
+g_naive = compute_grad(NaiveAD());
+g_geomsum = compute_grad(GeomSum());
+g_maniter = compute_grad(ManualIter());
+# g_linsolve = compute_grad(KrylovKit.GMRES(; tol=1e-6));
 
 @show norm(g_geomsum - g_naive) / norm(g_naive)
 @show norm(g_maniter - g_naive) / norm(g_naive)
-@show norm(g_linsolve - g_naive) / norm(g_naive)
+# @show norm(g_linsolve - g_naive) / norm(g_naive)

--- a/examples/test_gradients.jl
+++ b/examples/test_gradients.jl
@@ -38,11 +38,11 @@ function compute_grad(gradient_alg)
     return g
 end
 
-g_naive = compute_grad(NaiveAD());
-g_geomsum = compute_grad(GeomSum());
-g_maniter = compute_grad(ManualIter());
-# g_linsolve = compute_grad(KrylovKit.GMRES(; tol=1e-6));
+g_naive = compute_grad(NaiveAD())
+g_geomsum = compute_grad(GeomSum())
+g_maniter = compute_grad(ManualIter())
+g_linsolve = compute_grad(KrylovKit.GMRES(; tol=1e-6))
 
 @show norm(g_geomsum - g_naive) / norm(g_naive)
 @show norm(g_maniter - g_naive) / norm(g_naive)
-# @show norm(g_linsolve - g_naive) / norm(g_naive)
+@show norm(g_linsolve - g_naive) / norm(g_naive)

--- a/examples/test_gradients.jl
+++ b/examples/test_gradients.jl
@@ -2,11 +2,7 @@ using LinearAlgebra
 using TensorKit, MPSKitModels, OptimKit
 using PEPSKit, KrylovKit
 
-
 using Zygote
-
-
-    
 
 # Square lattice Heisenberg Hamiltonian
 function square_lattice_heisenberg(; Jx=-1.0, Jy=1.0, Jz=-1.0)

--- a/src/PEPSKit.jl
+++ b/src/PEPSKit.jl
@@ -9,6 +9,7 @@ using TensorKit, KrylovKit, MPSKit, OptimKit
 using ChainRulesCore, Zygote
 
 include("utility/util.jl")
+include("utility/eigsolve.jl")
 include("utility/rotations.jl")
 
 include("states/abstractpeps.jl")

--- a/src/algorithms/ctmrg.jl
+++ b/src/algorithms/ctmrg.jl
@@ -68,7 +68,11 @@ function MPSKit.leading_boundary(state, alg::CTMRG, envinit=CTMRGEnv(state))
         ϵold = ϵ
     end
 
-    env′, = ctmrg_iter(state, env, alg)
+    # do one final iteration that does not change the spaces
+    alg_fixed = CTMRG(;
+        alg.trscheme, alg.tol, alg.maxiter, alg.miniter, alg.verbosity, fixedspace=true
+    )
+    env′, = ctmrg_iter(state, env, alg_fixed)
     envfix = gauge_fix(env, env′)
     check_elementwise_convergence(env, envfix; atol=alg.tol^(3 / 4)) ||
         @warn "CTMRG did not converge elementwise."

--- a/src/algorithms/ctmrg.jl
+++ b/src/algorithms/ctmrg.jl
@@ -79,17 +79,6 @@ function MPSKit.leading_boundary(state, alg::CTMRG, envinit=CTMRGEnv(state))
     return envfix
 end
 
-macro checkgrad(expr)
-    x = gensym(:x)
-    return esc(:(
-        Zygote.hook($expr) do $x
-            if !isfinite(norm($x))
-                @error $x
-            end
-        end
-    ))
-end
-
 # Fix gauge of corner end edge tensors from last and second last CTMRG iteration
 function gauge_fix(envprev::CTMRGEnv{C,T}, envfinal::CTMRGEnv{C,T}) where {C,T}
     # Check if spaces in envprev and envfinal are the same
@@ -131,9 +120,6 @@ function gauge_fix(envprev::CTMRGEnv{C,T}, envfinal::CTMRGEnv{C,T}) where {C,T}
         ρfinal = eigsolve(TransferMatrix(Tsfinal, M), ρinit, 1, :LM)[2][1]
 
         # Decompose and multiply
-        # Qprev, = leftorth(ρprev, ((1,), (2,)))  # QR decomposition leads to diverging gradients?
-        # Qfinal, = leftorth(ρfinal, ((1,), (2,)))
-        # σ = @checkgrad Qprev * Qfinal'
         Up, _, Vp = tsvd(ρprev)
         Uf, _, Vf = tsvd(ρfinal)
         Qprev = Up * Vp

--- a/src/algorithms/peps_opt.jl
+++ b/src/algorithms/peps_opt.jl
@@ -72,6 +72,7 @@ Evaluating the gradient of the cost function for CTMRG:
 - With AD, the gradient is computed by differentiating the cost function with respect to the PEPS tensors, including computing the environment tensors.
 - With explicit evaluation of the geometric sum, the gradient is computed by differentiating the cost function with the environment kept fixed, and then manually adding the gradient contributions from the environments.
 =#
+using Zygote: @showgrad
 
 function ctmrg_gradient((peps, envs), H, alg::PEPSOptimize{NaiveAD})
     E, g = withgradient(peps) do ψ

--- a/src/environments/ctmrgenv.jl
+++ b/src/environments/ctmrgenv.jl
@@ -135,12 +135,12 @@ end
 #     return e1
 # end
 
-function VectorInterface.add(e1, e2, α=1, β=1)
+function VectorInterface.add(e1::CTMRGEnv, e2::CTMRGEnv, α=1, β=1)
     corners = α * e1.corners + β * e2.corners
     edges = α * e1.edges + β * e2.edges
     return CTMRGEnv(corners, edges)
 end
-function VectorInterface.add!(e1, e2, α=1, β=1)
+function VectorInterface.add!(e1::CTMRGEnv, e2::CTMRGEnv, α=1, β=1)
     e1.corners .= α * e1.corners + β * e2.corners
     e1.edges .= α * e1.edges + β * e2.edges
     return e1

--- a/src/environments/ctmrgenv.jl
+++ b/src/environments/ctmrgenv.jl
@@ -98,7 +98,7 @@ LinearAlgebra.norm(e::CTMRGEnv) = norm(e.corners) + norm(e.edges)
 VectorInterface.scalartype(e::CTMRGEnv) = eltype(e.corners[1])
 
 # VectorInterface.zerovector(e::CTMRGEnv) = zerovector(e, scalartype(e))  # Why does uncommenting this error?
-function VectorInterface.zerovector(e::CTMRGEnv, ::Type{S}) where S<:Number
+function VectorInterface.zerovector(e::CTMRGEnv, ::Type{S}) where {S<:Number}
     return CTMRGEnv(
         map(c -> TensorMap(zeros, S, space(c)), e.corners),
         map(t -> TensorMap(zeros, S, space(t)), e.edges),

--- a/src/environments/ctmrgenv.jl
+++ b/src/environments/ctmrgenv.jl
@@ -92,67 +92,67 @@ function LinearAlgebra.dot(e₁::CTMRGEnv, e₂::CTMRGEnv)
     return dot(e₁.corners, e₂.corners) + dot(e₁.edges, e₂.edges)
 end
 
-LinearAlgebra.norm(e::CTMRGEnv) = norm(e.corners) + norm(e.edges)
+# VectorInterface
+# ---------------
 
-# VectorInterface (TODO: implement !! methods)
-VectorInterface.scalartype(e::CTMRGEnv) = eltype(e.corners[1])
+# Note: the following methods consider the environment tensors as separate components of one
+# big vector. In other words, the associated vector space is not the natural one associated
+# to the original (physical) system, and addition, scaling, etc. are performed element-wise.
 
-# VectorInterface.zerovector(e::CTMRGEnv) = zerovector(e, scalartype(e))  # Why does uncommenting this error?
-function VectorInterface.zerovector(e::CTMRGEnv, ::Type{S}) where {S<:Number}
+import VectorInterface as VI
+
+function VI.scalartype(::Type{CTMRGEnv{C,T}}) where {C,T}
+    S₁ = scalartype(C)
+    S₂ = scalartype(T)
+    return promote_type(S₁, S₂)
+end
+
+function VI.zerovector(env::CTMRGEnv, ::Type{S}) where {S<:Number}
+    _zerovector = Base.Fix2(zerovector, S)
+    return CTMRGEnv(map(_zerovector, env.corners), map(_zerovector, env.edges))
+end
+function VI.zerovector!(env::CTMRGEnv)
+    foreach(zerovector!, env.corners)
+    foreach(zerovector!, env.edges)
+    return env
+end
+VI.zerovector!!(env::CTMRGEnv) = zerovector!(env)
+
+function VI.scale(env::CTMRGEnv, α::Number)
+    _scale = Base.Fix2(scale, α)
+    return CTMRGEnv(map(_scale, env.corners), map(_scale, env.edges))
+end
+function VI.scale!(env::CTMRGEnv, α::Number)
+    _scale! = Base.Fix2(scale!, α)
+    foreach(_scale!, env.corners)
+    foreach(_scale!, env.edges)
+    return env
+end
+function VI.scale!(env₁::CTMRGEnv, env₂::CTMRGEnv, α::Number)
+    _scale!(x, y) = scale!(x, y, α)
+    foreach(_scale!, env₁.corners, env₂.corners)
+    foreach(_scale!, env₁.edges, env₂.edges)
+    return env₁
+end
+VI.scale!!(env::CTMRGEnv, α::Number) = scale!(env, α)
+VI.scale!!(env₁::CTMRGEnv, env₂::CTMRGEnv, α::Number) = scale!(env₁, env₂, α)
+
+function VI.add(env₁::CTMRGEnv, env₂::CTMRGEnv, α::Number, β::Number)
+    _add(x, y) = add(x, y, α, β)
     return CTMRGEnv(
-        map(c -> TensorMap(zeros, S, space(c)), e.corners),
-        map(t -> TensorMap(zeros, S, space(t)), e.edges),
+        map(_add, env₁.corners, env₂.corners), map(_add, env₁.corners, env₂.corners)
     )
 end
-function VectorInterface.zerovector!(e::CTMRGEnv)
-    e.corners .= map(c -> TensorMap(zeros, S, space(c)), e.corners)
-    e.edges .= map(t -> TensorMap(zeros, S, space(t)), e.edges)
-    return e
+function VI.add!(env₁::CTMRGEnv, env₂::CTMRGEnv, α::Number, β::Number)
+    _add!(x, y) = add!(x, y, α, β)
+    foreach(_add!, env₁.corners, env₂.corners)
+    foreach(_add!, env₁.edges, env₂.edges)
+    return env₁
 end
-# function VectorInterface.zerovector!!(e::CTMRGEnv, S::Number)
-#     return CTMRGEnv(
-#         map(c -> TensorMap(zeros, S, space(c)), e.corners),
-#         map(t -> TensorMap(zeros, S, space(t)), e.edges),
-#     )
-# end
-# VectorInterface.zerovector!!(e::CTMRGEnv) = zerovector!!(e, scalartype(e))
+VI.add!!(env₁::CTMRGEnv, env₂::CTMRGEnv, α::Number, β::Number) = add!(env₁, env₂, α, β)
 
-VectorInterface.scale(e::CTMRGEnv, α::Number) = CTMRGEnv(α * e.corners, α * e.edges)
-function VectorInterface.scale!(e::CTMRGEnv, α::Number)
-    e.corners .*= α
-    e.edges .*= α
-    return e
+# exploiting the fact that vectorinterface works for tuples:
+function VI.inner(env₁::CTMRGEnv, env₂::CTMRGEnv)
+    return inner((env₁.corners, env₁.edges), (env₂.corners, env₂.edges))
 end
-function VectorInterface.scale!(e1::CTMRGEnv, e2::CTMRGEnv, α)
-    e1.corners .= α * e2.corners
-    e1.edges .= α * e2.edges
-    return e1
-end
-# VectorInterface.scale!!(e::CTMRGEnv, α::Number) = CTMRGEnv(α * e.corners, α * e.edges)
-# function VectorInterface.scale!!(e1::CTMRGEnv, e2::CTMRGEnv, α::Number)
-#     e1.corners .= α * e2.corners
-#     e1.edges .= α * e2.edges
-#     return e1
-# end
-
-function VectorInterface.add(e1::CTMRGEnv, e2::CTMRGEnv, α=1, β=1)
-    corners = α * e1.corners + β * e2.corners
-    edges = α * e1.edges + β * e2.edges
-    return CTMRGEnv(corners, edges)
-end
-function VectorInterface.add!(e1::CTMRGEnv, e2::CTMRGEnv, α=1, β=1)
-    e1.corners .= α * e1.corners + β * e2.corners
-    e1.edges .= α * e1.edges + β * e2.edges
-    return e1
-end
-# function VectorInterface.add!!(e1, e2, α=1, β=1)
-#     corners = α * e1.corners + β * e2.corners
-#     edges = α * e1.edges + β * e2.edges
-#     return CTMRGEnv(corners, edges)
-# end
-
-function VectorInterface.inner(e1::CTMRGEnv, e2::CTMRGEnv)
-    return dot(e1.corners, e2.corners) + dot(e1.edges, e2.edges)
-end
-
-VectorInterface.norm(e::CTMRGEnv) = norm(e.corners) + norm(e.edges)
+VI.norm(env::CTMRGEnv) = norm((env.corners, env.edges))

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -64,7 +64,7 @@ function InfinitePEPS(A::T; unitcell::Tuple{Int,Int}=(1, 1)) where {T<:PEPSTenso
 end
 
 """
-    InfinitePEPS(Pspace, Nspace, [Espace]; unitcell=(1,1))
+    InfinitePEPS(f=randn, T=ComplexF64, Pspace, Nspace, [Espace]; unitcell=(1,1))
 
 Create an InfinitePEPS by specifying its spaces and unit cell. Spaces can be specified
 either via `Int` or via `ElementarySpace`.
@@ -73,7 +73,14 @@ function InfinitePEPS(
     Pspace::S, Nspace::S, Espace::S=Nspace; unitcell::Tuple{Int,Int}=(1, 1)
 ) where {S<:Union{ElementarySpace,Int}}
     return InfinitePEPS(
-        fill(Pspace, unitcell), fill(Nspace, unitcell), fill(Espace, unitcell)
+        randn, ComplexF64, fill(Pspace, unitcell), fill(Nspace, unitcell), fill(Espace, unitcell)
+    )
+end
+function InfinitePEPS(
+    f, T, Pspace::S, Nspace::S, Espace::S=Nspace; unitcell::Tuple{Int,Int}=(1, 1)
+) where {S<:Union{ElementarySpace,Int}}
+    return InfinitePEPS(
+        f, T, fill(Pspace, unitcell), fill(Nspace, unitcell), fill(Espace, unitcell)
     )
 end
 

--- a/src/states/infinitepeps.jl
+++ b/src/states/infinitepeps.jl
@@ -73,7 +73,11 @@ function InfinitePEPS(
     Pspace::S, Nspace::S, Espace::S=Nspace; unitcell::Tuple{Int,Int}=(1, 1)
 ) where {S<:Union{ElementarySpace,Int}}
     return InfinitePEPS(
-        randn, ComplexF64, fill(Pspace, unitcell), fill(Nspace, unitcell), fill(Espace, unitcell)
+        randn,
+        ComplexF64,
+        fill(Pspace, unitcell),
+        fill(Nspace, unitcell),
+        fill(Espace, unitcell),
     )
 end
 function InfinitePEPS(

--- a/src/utility/eigsolve.jl
+++ b/src/utility/eigsolve.jl
@@ -1,0 +1,253 @@
+# Copied from Jutho/KrylovKit.jl/pull/56, with minor tweaks
+
+function ChainRulesCore.rrule(
+    ::typeof(eigsolve), A::AbstractMatrix, x₀, howmany, which, alg
+)
+    (vals, vecs, info) = eigsolve(A, x₀, howmany, which, alg)
+    project_A = ProjectTo(A)
+    T = eltype(vecs[1]) # will be real for real symmetric problems and complex otherwise
+
+    function eigsolve_pullback(ΔX)
+        _Δvals = unthunk(ΔX[1])
+        _Δvecs = unthunk(ΔX[2])
+
+        ∂self = NoTangent()
+        ∂x₀ = ZeroTangent()
+        ∂howmany = NoTangent()
+        ∂which = NoTangent()
+        ∂alg = NoTangent()
+        if _Δvals isa AbstractZero && _Δvecs isa AbstractZero
+            ∂A = ZeroTangent()
+            return ∂self, ∂A, ∂x₀, ∂howmany, ∂which, ∂alg
+        end
+
+        if _Δvals isa AbstractZero
+            Δvals = fill(NoTangent(), length(Δvecs))
+        else
+            Δvals = _Δvals
+        end
+        if _Δvecs isa AbstractZero
+            Δvecs = fill(NoTangent(), length(Δvals))
+        else
+            Δvecs = _Δvecs
+        end
+
+        @assert length(Δvals) == length(Δvecs)
+        @assert length(Δvals) <= length(vals)
+
+        # Determine algorithm to solve linear problem
+        # TODO: Is there a better choice? Should we make this user configurable?
+        linalg = GMRES(;
+            tol=alg.tol, krylovdim=alg.krylovdim, maxiter=alg.maxiter, orth=alg.orth
+        )
+
+        ws = similar(vecs, length(Δvecs))
+        for i in 1:length(Δvecs)
+            Δλ = Δvals[i]
+            Δv = Δvecs[i]
+            λ = vals[i]
+            v = vecs[i]
+
+            # First threat special cases
+            if isa(Δv, AbstractZero) && isa(Δλ, AbstractZero) # no contribution
+                ws[i] = Δv # some kind of zero
+                continue
+            end
+            if isa(Δv, AbstractZero) && isa(alg, Lanczos) # simple contribution
+                ws[i] = Δλ * v
+                continue
+            end
+
+            # General case :
+            if isa(Δv, AbstractZero)
+                b = RecursiveVec(zero(T) * v, T[Δλ])
+            else
+                @assert isa(Δv, typeof(v))
+                b = RecursiveVec(Δv, T[Δλ])
+            end
+
+            if i > 1 &&
+                eltype(A) <: Real &&
+                vals[i] == conj(vals[i - 1]) &&
+                Δvals[i] == conj(Δvals[i - 1]) &&
+                vecs[i] == conj(vecs[i - 1]) &&
+                Δvecs[i] == conj(Δvecs[i - 1])
+                ws[i] = conj(ws[i - 1])
+                continue
+            end
+
+            w, reverse_info = let λ = λ, v = v, Aᴴ = A'
+                linsolve(b, zero(T) * b, linalg) do x
+                    x1, x2 = x
+                    γ = 1
+                    # γ can be chosen freely and does not affect the solution theoretically
+                    # The current choice guarantees that the extended matrix is Hermitian if A is
+                    # TODO: is this the best choice in all cases?
+                    y1 = axpy!(-γ * x2[], v, axpy!(-conj(λ), x1, A' * x1))
+                    y2 = T[-dot(v, x1)]
+                    return RecursiveVec(y1, y2)
+                end
+            end
+            if info.converged >= i && reverse_info.converged == 0
+                @warn "The cotangent linear problem did not converge, whereas the primal eigenvalue problem did."
+            end
+            ws[i] = w[1]
+        end
+
+        if A isa StridedMatrix
+            ∂A = InplaceableThunk(
+                Ā -> _buildĀ!(Ā, ws, vecs), @thunk(_buildĀ!(zero(A), ws, vecs))
+            )
+        else
+            ∂A = @thunk(project_A(_buildĀ!(zero(A), ws, vecs)))
+        end
+        return ∂self, ∂A, ∂x₀, ∂howmany, ∂which, ∂alg
+    end
+    return (vals, vecs, info), eigsolve_pullback
+end
+
+function _buildĀ!(Ā, ws, vs)
+    for i in 1:length(ws)
+        w = ws[i]
+        v = vs[i]
+        if !(w isa AbstractZero)
+            if eltype(Ā) <: Real && eltype(w) <: Complex
+                mul!(Ā, _realview(w), _realview(v)', -1, 1)
+                mul!(Ā, _imagview(w), _imagview(v)', -1, 1)
+            else
+                mul!(Ā, w, v', -1, 1)
+            end
+        end
+    end
+    return Ā
+end
+function _realview(v::AbstractVector{Complex{T}}) where {T}
+    return view(reinterpret(T, v), 2 * (1:length(v)) .- 1)
+end
+function _imagview(v::AbstractVector{Complex{T}}) where {T}
+    return view(reinterpret(T, v), 2 * (1:length(v)))
+end
+
+function ChainRulesCore.rrule(
+    config::RuleConfig{>:HasReverseMode},
+    ::typeof(eigsolve),
+    A::AbstractMatrix,
+    x₀,
+    howmany,
+    which,
+    alg,
+)
+    return ChainRulesCore.rrule(eigsolve, A, x₀, howmany, which, alg)
+end
+
+function ChainRulesCore.rrule(
+    config::RuleConfig{>:HasReverseMode}, ::typeof(eigsolve), f, x₀, howmany, which, alg
+)
+    (vals, vecs, info) = eigsolve(f, x₀, howmany, which, alg)
+
+    T = typeof(dot(vecs[1], vecs[1]))
+    f_pullbacks = map(x -> rrule_via_ad(config, f, x)[2], vecs)
+
+    function eigsolve_pullback(ΔX)
+        _Δvals = unthunk(ΔX[1])
+        _Δvecs = unthunk(ΔX[2])
+
+        ∂self = NoTangent()
+        ∂x₀ = ZeroTangent()
+        ∂howmany = NoTangent()
+        ∂which = NoTangent()
+        ∂alg = NoTangent()
+        if _Δvals isa AbstractZero && _Δvecs isa AbstractZero
+            ∂A = ZeroTangent()
+            return (∂self, ∂A, ∂x₀, ∂howmany, ∂which, ∂alg)
+        end
+
+        if _Δvals isa AbstractZero
+            Δvals = fill(NoTangent(), howmany)
+        else
+            Δvals = _Δvals
+        end
+        if _Δvecs isa AbstractZero
+            Δvecs = fill(NoTangent(), howmany)
+        else
+            Δvecs = _Δvecs
+        end
+
+        # filter ZeroTangents, added compared to Jutho/KrylovKit.jl/pull/56
+        Δvecs = filter(x -> !(x isa AbstractZero), Δvecs)
+
+        @assert length(Δvals) == length(Δvecs)
+
+        # Determine algorithm to solve linear problem
+        # TODO: Is there a better choice? Should we make this user configurable?
+        linalg = GMRES(;
+            tol=alg.tol,
+            krylovdim=alg.krylovdim + 10,
+            maxiter=alg.maxiter * 10,
+            orth=alg.orth,
+        )
+        # linalg = BiCGStab(;
+        #     tol = alg.tol,
+        #     maxiter = alg.maxiter*alg.krylovdim,
+        # )
+
+        ws = similar(Δvecs)
+        for i in 1:length(Δvecs)
+            Δλ = Δvals[i]
+            Δv = Δvecs[i]
+            λ = vals[i]
+            v = vecs[i]
+
+            # First threat special cases
+            if isa(Δv, AbstractZero) && isa(Δλ, AbstractZero) # no contribution
+                ws[i] = Δv # some kind of zero
+                continue
+            end
+            if isa(Δv, AbstractZero) && isa(alg, Lanczos) # simple contribution
+                ws[i] = Δλ * v
+                continue
+            end
+
+            # General case :
+            if isa(Δv, AbstractZero)
+                b = RecursiveVec(zero(T) * v, T[-Δλ])
+            else
+                @assert isa(Δv, typeof(v))
+                b = RecursiveVec(-Δv, T[-Δλ])
+            end
+
+            # TODO: is there any analogy to this for general vector-like user types
+            # if i > 1 && eltype(A) <: Real &&
+            #     vals[i] == conj(vals[i-1]) && Δvals[i] == conj(Δvals[i-1]) &&
+            #     vecs[i] == conj(vecs[i-1]) && Δvecs[i] == conj(Δvecs[i-1])
+            #
+            #     ws[i] = conj(ws[i-1])
+            #     continue
+            # end
+
+            w, reverse_info = let λ = λ, v = v, fᴴ = x -> f_pullbacks[i](x)[2]
+                linsolve(b, zero(T) * b, linalg) do x
+                    x1, x2 = x
+                    γ = 1
+                    # γ can be chosen freely and does not affect the solution theoretically
+                    # The current choice guarantees that the extended matrix is Hermitian if A is
+                    # TODO: is this the best choice in all cases?
+                    y1 = axpy!(-γ * x2[], v, axpy!(-conj(λ), x1, fᴴ(x1)))
+                    y2 = T[-dot(v, x1)]
+                    return RecursiveVec(y1, y2)
+                end
+            end
+            if info.converged >= i && reverse_info.converged == 0
+                @warn "The cotangent linear problem ($i) did not converge, whereas the primal eigenvalue problem did."
+            end
+            ws[i] = w[1]
+        end
+
+        ∂f = f_pullbacks[1](ws[1])[1]
+        for i in 2:length(ws)
+            ∂f = VectorInterface.add!!(∂f, f_pullbacks[i](ws[i])[1])
+        end
+        return ∂self, ∂f, ∂x₀, ∂howmany, ∂which, ∂alg
+    end
+    return (vals, vecs, info), eigsolve_pullback
+end

--- a/src/utility/rotations.jl
+++ b/src/utility/rotations.jl
@@ -10,22 +10,3 @@ const SOUTHWEST = 4
 
 # Rotate tensor to any direction by successive application of Base.rotl90
 rotate_north(t, dir) = mod1(dir, 4) == NORTH ? t : rotate_north(rotl90(t), dir - 1)
-
-# Hacked version for AbstractArray{T,3} which doesn't need to overload rotl90 to avoid type piracy
-function rotate_north(A::AbstractArray{T,3}, dir) where {T}
-    for _ in 1:(mod1(dir, size(A, 1)) - 1)
-        # Initialize copy with rotated sizes
-        A′ = Zygote.Buffer(Array{T,3}(undef, size(A, 1), size(A, 3), size(A, 2)))
-        for dir in 1:size(A, 1)
-            # A′[_prev(dir, size(A, 1)), :, :] = rotl90(A[dir, :, :])
-            # throws setindex! error for non-symmetric unit cells
-            rA = rotl90(A[dir, :, :])
-            for r in 1:size(A, 3), c in 1:size(A, 2)
-                A′[_prev(dir, size(A, 1)), r, c] = rA[r, c]
-            end
-        end
-        A = A′
-    end
-
-    return copy(A)
-end


### PR DESCRIPTION
Placeholder PR for an update to the gauge fixing algorithm to one that works for symmetric `TensorMap`s. This implementation fixes the issues #18 , but it breaks the AD since it uses `KrylokvKit.eigsolve` which is not differentiable. Hopefully this works once we add the corresponding rrule.

We should probably also try the [other approaches](https://arxiv.org/abs/2311.11894), but this seemed the simplest one that worked so just adding it here for reference and discussion.